### PR TITLE
Replace Azure pipelines with Github Actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,33 @@
+name: brew pr-pull
+on:
+  pull_request_target:
+    types:
+      - labeled
+jobs:
+  pr-pull:
+    if: contains(github.event.pull_request.labels.*.name, 'pr-pull')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+
+      - name: Set up git
+        uses: Homebrew/actions/git-user-config@master
+
+      - name: Pull bottles
+        env:
+          HOMEBREW_GITHUB_API_TOKEN: ${{ github.token }}
+          PULL_REQUEST: ${{ github.event.pull_request.number }}
+        run: brew pr-pull --debug --tap=$GITHUB_REPOSITORY $PULL_REQUEST
+
+      - name: Push commits
+        uses: Homebrew/actions/git-try-push@master
+        with:
+          token: ${{ github.token }}
+          branch: main
+
+      - name: Delete branch
+        if: github.event.pull_request.head.repo.fork == false
+        env:
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+        run: git push --delete origin $BRANCH

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,43 @@
+name: brew test-bot
+on:
+  push:
+    branches: main
+  pull_request:
+jobs:
+  test-bot:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+
+      - name: Cache Homebrew Bundler RubyGems
+        id: cache
+        uses: actions/cache@v1
+        with:
+          path: ${{ steps.set-up-homebrew.outputs.gems-path }}
+          key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
+          restore-keys: ${{ runner.os }}-rubygems-
+
+      - name: Install Homebrew Bundler RubyGems
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: brew install-bundler-gems
+
+      - run: brew test-bot --only-cleanup-before
+
+      - run: brew test-bot --only-setup
+
+      - run: brew test-bot --only-tap-syntax
+
+      - run: brew test-bot --only-formulae
+        if: github.event_name == 'pull_request'
+
+      - name: Upload bottles as artifact
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/upload-artifact@main
+        with:
+          name: bottles
+          path: '*.bottle.*'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest]
+      fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Homebrew

--- a/Formula/avr-binutils.rb
+++ b/Formula/avr-binutils.rb
@@ -7,12 +7,6 @@ class AvrBinutils < Formula
 
   depends_on "gpatch" => :build if OS.linux?
 
-  bottle do
-    root_url "https://dl.bintray.com/osx-cross/bottles-avr"
-    sha256 "5c95ebe6b2e9a36115ca9ef1debb9dcfb140f65df1ffa2f2ef03e2dbbb676fa8" => :mojave
-    sha256 "42185c4eaa583f5e3985846afadf4abcdf4c5e3e54cc2da288c9cd2d4da8e05c" => :high_sierra
-  end
-
   uses_from_macos "zlib"
 
   # Support for -C in avr-size. See issue

--- a/Formula/avr-gcc.rb
+++ b/Formula/avr-gcc.rb
@@ -9,10 +9,7 @@ class AvrGcc < Formula
   head "https://gcc.gnu.org/git/gcc.git"
 
   bottle do
-    root_url "https://dl.bintray.com/osx-cross/bottles-avr"
-    rebuild 1
-    sha256 "aaf39cac6784b9d9ecb59ca599201144e4cdb11659d5b3799e811ce710296e2d" => :catalina
-    sha256 "d9a67510da4bfe62827c57238ef506ab8513a6b0fbafa51fd26ea5c9e8c35ab5" => :mojave
+    cellar :any_skip_relocation
   end
 
   # The bottles are built on systems with the CLT installed, and do not work
@@ -26,8 +23,8 @@ class AvrGcc < Formula
 
   # automake & autoconf are needed to build from source
   # with the ATMega168pbSupport option.
-  depends_on "automake" => :build
   depends_on "autoconf" => :build
+  depends_on "automake" => :build
 
   depends_on "avr-binutils"
 

--- a/Formula/avr-gdb.rb
+++ b/Formula/avr-gdb.rb
@@ -8,12 +8,6 @@ class AvrGdb < Formula
 
   head "https://sourceware.org/git/binutils-gdb.git"
 
-  bottle do
-    root_url "https://dl.bintray.com/osx-cross/bottles-avr"
-    sha256 "ec8b5fd6b277c0c7b2feae51844279e80851420049a70c84db9ddc2a76df0511" => :mojave
-    sha256 "9b330c3f2e4781d7a57f86f9df24c7f401239099af1000b2b94fb56b5253ed6d" => :high_sierra
-  end
-
   depends_on "pkg-config" => :build
   depends_on "avr-binutils"
 


### PR DESCRIPTION
Github Action workflows copied from `brew tap-new` (inside `docker run -it homebrew/brew` on Linux).